### PR TITLE
Updated Simplified Chinese translation repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For Aseprite v1.3.2 and older versions, here a list of translations
 created by Aseprite users and distributed as extensions:
 
 - 🇨🇳 Chinese
-- - 🇨🇳 [Simplified Chinese](https://steamcommunity.com/sharedfiles/filedetails/?id=1333477949)
+- - 🇨🇳 [Simplified Chinese](https://github.com/Cetaceaqua/Aseprite-Simplified-Chinese-Extension)([Simplified Chinese (1.3-rc1)](https://steamcommunity.com/sharedfiles/filedetails/?id=1333477949))
 - - 🇨🇳 [Traditional Chinese](https://github.com/chongx1an/aseprite-TraditionalChineseExtension) ([Traditional Chinese & font (v1.2.28)](https://github.com/SiderealArt/Aseprite-Traditional-Chinese-Translation))
 - 🇫🇷 [French](https://github.com/realBoubli/Aseprite-French-Translation) ([French alternative](https://github.com/farvardin/aseprite_french))
 - 🇩🇪 [German](https://github.com/inxomnyaa/Aseprite-German-Translation) ([German alternative](https://github.com/dotheflopboy/Aseprite-German-Translation))

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For Aseprite v1.3.2 and older versions, here a list of translations
 created by Aseprite users and distributed as extensions:
 
 - 🇨🇳 Chinese
-- - 🇨🇳 [Simplified Chinese](https://github.com/Cetaceaqua/Aseprite-Simplified-Chinese-Extension)([Simplified Chinese (1.3-rc1)](https://steamcommunity.com/sharedfiles/filedetails/?id=1333477949))
+- - 🇨🇳 [Simplified Chinese](https://github.com/Cetaceaqua/Aseprite-Simplified-Chinese-Extension) ([Simplified Chinese (1.3-rc1)](https://steamcommunity.com/sharedfiles/filedetails/?id=1333477949))
 - - 🇨🇳 [Traditional Chinese](https://github.com/chongx1an/aseprite-TraditionalChineseExtension) ([Traditional Chinese & font (v1.2.28)](https://github.com/SiderealArt/Aseprite-Traditional-Chinese-Translation))
 - 🇫🇷 [French](https://github.com/realBoubli/Aseprite-French-Translation) ([French alternative](https://github.com/farvardin/aseprite_french))
 - 🇩🇪 [German](https://github.com/inxomnyaa/Aseprite-German-Translation) ([German alternative](https://github.com/dotheflopboy/Aseprite-German-Translation))


### PR DESCRIPTION
Updated the repo link to my fork based on J-11's old translation for 1.3-rc1, updated to 1.3.2, fixed some long-standing translation issues, and will soon update a new theme extension with the officially licensed Dinkie Bitmap font.

I started working on my fork at the end of November, completely unaware of the official start of Weblate translation, what an awkward timing!

I will try to contact the current Simplified Chinese contributors on Weblate and work with them to continue to improve the Simplified Chinese localization of Aseprite.

Thank you for such a great pixel art editor, I've been immersed in it for over 1k hours! ❤
